### PR TITLE
Remove trailing whitespace from translator's title

### DIFF
--- a/HdRezkaApi/HdRezkaApi.py
+++ b/HdRezkaApi/HdRezkaApi.py
@@ -73,7 +73,7 @@ class HdRezkaApi():
 			children = translators.findChildren(recursive=False)
 			for child in children:
 				if child.text:
-					arr[child.text] = int(child.attrs['data-translator_id'])
+					arr[child.text.strip()] = int(child.attrs['data-translator_id'])
 		if not arr:
 			#auto-detect
 			def getTranslationName(s):


### PR DESCRIPTION
It would be great to have the translators list clean, without any trailing whitespace.

<img width="550" alt="Screenshot 2025-01-05 at 01 00 50" src="https://github.com/user-attachments/assets/e01eebf4-b75a-4428-a53f-2e982d602967" />
