### PR TITLE
Fix api error

### DIFF
--- a/HdRezkaApi/api.py
+++ b/HdRezkaApi/api.py
@@ -367,6 +367,7 @@ class HdRezkaApi():
 			return makeRequest({
 				"id": self.id,
 				"translator_id": translation_id,
+				"is_director": 0,
 				"action": "get_movie"
 			})
 


### PR DESCRIPTION
Fixed error {'success': False, 'message': 'Время сессии истекло. Пожалуйста, обновите страницу и повторите попытку'}  The is_director parameter has become mandatory for movies

Некоторые фильмы можно получить если is_director = 0 некоторые если is_director = 1